### PR TITLE
Add quotes around path

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -28,9 +28,9 @@ class RunManager {
             currentTerminal.show()
 
             // If file is a processing project file
-            const cmd = `${getProcessingCommand()} --sketch=${dirname(
+            const cmd = `${getProcessingCommand()} --sketch="${dirname(
                 editor.document.fileName,
-            )} --run`
+            )}" --run`
 
             currentTerminal.sendText(cmd)
         }


### PR DESCRIPTION
The quotes around the path variable allows the command to work with paths with whitespace.