### PR TITLE
feat: add snippets for circle() and square()

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -269,6 +269,12 @@
     "description": "char",
     "scope": "source.pde"
   },
+  "circle": {
+    "prefix": "circle",
+    "body": "circle(${1:x}, ${2:y}, ${3:extent});",
+    "description": "circle",
+    "scope": "source.pde"
+  },
   "class": {
     "prefix": "class",
     "body": "${1:public }class ${2:${TM_FILENAME/(.*?)(\\..+)/$1/}} ${3:extends} {\n\n\tpublic $2 (${4:arguments}) {\n\t\t${0}\n\t}\n\n}\n",
@@ -1629,6 +1635,12 @@
     "prefix": "sqrt",
     "body": "sqrt(${1:value});",
     "description": "sqrt",
+    "scope": "source.pde"
+  },
+  "square": {
+    "prefix": "square",
+    "body": "square(${1:x}, ${2:y}, ${3:extent});",
+    "description": "square",
     "scope": "source.pde"
   },
   "status": {


### PR DESCRIPTION
Offer code snippets for `circle()` and `square()` methods, introduced in Processing 3.5 (see [changelog](https://github.com/processing/processing/releases#:~:text=Compare-,Processing%203.5,-benfry%20released%20this) or [reference](https://processing.org/reference/circle_.html)).
As seen in [documentation-data.yml](https://github.com/Luke-zhang-04/processing-vscode/blob/master/data/documentation-data.yml#L1184), documentations for both have already been fetched and so appear on hover.