### PR TITLE
feat(run): allow interruption of running processing program

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ This is a [fork of a Visual Studio Code extension created by Tobiah Zarlez](http
 ## What this extension isn't
 
 -   This extension does not allow you to debug Java or Processing projects.
--   This is **NOT a language server**, and hence cannot provide the features a language server can. There simply is not enough demand for a Processing language server, and that type of thing is definetly out of the scope of my abilities. Langauge servers take entire teams from big companies such as Microsoft to make.
-    -   This extension cannot provide intellesence, for example
+-   This is **NOT a language server**, and hence cannot provide the features a language server can. There simply is not enough demand for a Processing language server, and that type of thing is definitely out of the scope of my abilities. Language servers take entire teams from big companies such as Microsoft to make.
+    -   This extension cannot provide IntelliSense, for example
 
 ## Why the fork?
 

--- a/README.md
+++ b/README.md
@@ -116,3 +116,8 @@ This extension attempts to make Processing with Python easier to use. Follow the
 -   Snippets are based on the [Processing Sublime Text plugin](https://github.com/b-g/processing-sublime).
 -   Syntax highlighting is based on the [Red Hat VSCode-Java extension grammar](https://github.com/redhat-developer/vscode-java/blob/master/syntaxes/java.tmLanguage.json)
 -   Thanks to [Tobiah Zarlez](https://github.com/TobiahZ) for making the [original extension](https://github.com/TobiahZ/processing-vscode)
+
+## Development
+
+- Run `yarn vsce package`
+- Run `code --install-extension processing-vscode-<VERSION>.vsix`

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Installing this extension will add the following commands to your command pallet
     -   Use the pallet command "Processing: Open Documentation for Selection" to open the processing documentation for the current selection.
     -   By default uses processing.org's documentation. Can change to p5js's if preferred using the `processing.docs` setting.
 -   Run
-    -   Runs the current Processing project (from current working directory). Will automatically detect if the project is Processing Java or Python
+    -   Runs the current Processing project (from current working directory). Will automatically detect if the project is Processing Java or Python.
+    -   If the setting `processing.shouldSendSigint` is set to `true`, run will interrupt the current running processing program before running the new one.
 -   RunJava
     -   Runs the current Processing Java project (from CWD)
 -   RunPy

--- a/README.md
+++ b/README.md
@@ -119,5 +119,5 @@ This extension attempts to make Processing with Python easier to use. Follow the
 
 ## Development
 
-- Run `yarn vsce package`
-- Run `code --install-extension processing-vscode-<VERSION>.vsix`
+-   Run `yarn vsce package`
+-   Run `code --install-extension processing-vscode-<VERSION>.vsix`

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "keywords": [
     "processing",
     "pde",
-    "procesing.py",
+    "processing.py",
     "processing-python",
     "language",
     "snippets",
@@ -205,7 +205,12 @@
         "processing.shouldGiveDiagnostics": {
           "type": "boolean",
           "default": false,
-          "description": "If the extension should provide diagnostics (via processing-java)"
+          "description": "If the extension should provide diagnostics (via processing-java). Note that this feature is quite slow."
+        },
+        "processing.shouldSendSigint": {
+          "type": "boolean",
+          "default": false,
+          "description": "If the extension should send sigint to the terminal stop the current running processing program before running the new one by sending \"\\x03\" (^C). If true, it essentially presses ctrl+c for you."
         },
         "processing.runPathQuotes": {
           "type": "string",
@@ -224,7 +229,7 @@
         "processing.py.javaPath": {
           "type": "string",
           "default": "java",
-          "description": "Path to Java. Leave default if you've added java to your path, otherwise enter the path to `java` here. Example: `/usr/bin/java` for Unix, or `C:\\Program Files\\Java\\jdk1.8.0_202\\bin\\javac.exe` for Windows."
+          "description": "Path to Java. Leave default if you've added java to your path, otherwise enter the path to `java` here. Example: `/usr/bin/java` for Unix, or potentially `C:\\Program Files\\Java\\jdk1.8.0_202\\bin\\javac.exe` for Windows."
         },
         "processing.py.isEnabled": {
           "type": "boolean",

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -4,7 +4,13 @@
  * @copyright (C) 2021 Luke Zhang
  */
 
-import {jarPath, javaCommand, processingCommand, shouldAlwaysQuotePath} from "../config"
+import {
+    jarPath,
+    javaCommand,
+    processingCommand,
+    shouldAlwaysQuotePath,
+    shouldSendSigint,
+} from "../config"
 import path, {dirname} from "path"
 import {isValidProcessingProject} from "../utils"
 import vscode from "vscode"
@@ -76,7 +82,10 @@ class RunManager {
      * @param editor - Vscode text editor
      */
     private _runJavaMode = (editor: vscode.TextEditor): void => {
-        const currentTerminal = this._getTerminal("_terminal", "Processing")
+        const terminalName = "_terminal"
+        const hasTerminal =
+            this[terminalName] !== undefined && this[terminalName]?.exitStatus === undefined
+        const currentTerminal = this._getTerminal(terminalName, "Processing")
 
         let sketchName = dirname(editor.document.fileName)
         const isValidProjectName = isValidProcessingProject(sketchName.split(path.sep).pop())
@@ -95,7 +104,9 @@ class RunManager {
         }
 
         // If file is a processing project file
-        const cmd = `${processingCommand} --sketch=${sketchName} --run`
+        const cmd = `${
+            hasTerminal && shouldSendSigint ? "\x03" : ""
+        }${processingCommand} --sketch=${sketchName} --run`
 
         currentTerminal.sendText(cmd)
     }
@@ -106,12 +117,17 @@ class RunManager {
      * @param editor - Vscode text editor
      */
     private _runPythonMode = (editor: vscode.TextEditor): void => {
-        const currentTerminal = this._getTerminal("_pythonTerminal", "Processing-py")
+        const terminalName = "_terminal"
+        const hasTerminal =
+            this[terminalName] !== undefined && this[terminalName]?.exitStatus === undefined
+        const currentTerminal = this._getTerminal(terminalName, "Processing-py")
 
         currentTerminal.show()
 
         // If file is a processing project file
-        const cmd = `${javaCommand} -jar ${pythonUtils.getJarFilename()} ${pythonUtils.getProjectFilename(
+        const cmd = `${
+            hasTerminal && shouldSendSigint ? "\x03" : ""
+        }${javaCommand} -jar ${pythonUtils.getJarFilename()} ${pythonUtils.getProjectFilename(
             editor.document,
         )}`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,7 +54,7 @@ const getJarPath = (): string => {
     return config
 }
 
-const getPythonEnablement = (): boolean => {
+const getShouldEnablePython = (): boolean => {
     const isEnabled = vscode.workspace
         .getConfiguration()
         .get<boolean>("processing.py.isEnabled", true)
@@ -105,7 +105,7 @@ const getshouldEnableDiagnostics = (): boolean => {
         .get<boolean>("processing.shouldGiveDiagnostics", true)
 
     if (typeof shouldGiveDiagnostics !== "boolean") {
-        const msg = "Config option processing.shouldGiveDiagnostics must be of type string"
+        const msg = "Config option processing.shouldGiveDiagnostics must be of type boolean"
 
         vscode.window.showErrorMessage(msg)
 
@@ -131,13 +131,30 @@ const getQuoteEnablement = (): boolean => {
     return shouldQuotePath === "always"
 }
 
+const getShouldSendSigint = (): boolean => {
+    const isEnabled = vscode.workspace
+        .getConfiguration()
+        .get<boolean>("processing.shouldSendSigint", false)
+
+    if (typeof isEnabled !== "boolean") {
+        const msg = "Config option processing.shouldSendSigint must be of type boolean"
+
+        vscode.window.showErrorMessage(msg)
+
+        throw new Error(msg)
+    }
+
+    return isEnabled
+}
+
 export const processingCommand = getProcessingCommand()
 export const javaCommand = getJavaCommand()
 export const jarPath = getJarPath()
-export const shouldEnablePython = getPythonEnablement()
+export const shouldEnablePython = getShouldEnablePython()
 export const searchConfig = getSearchConfig()
 export const shouldEnableDiagnostics = getshouldEnableDiagnostics()
 export const shouldAlwaysQuotePath = getQuoteEnablement()
+export const shouldSendSigint = getShouldSendSigint()
 
 export default {
     processingCommand,
@@ -147,4 +164,5 @@ export default {
     searchConfig,
     shouldEnableDiagnostics,
     shouldAlwaysQuotePath,
+    shouldSendSigint,
 }


### PR DESCRIPTION
Feature for #14

- Sends sigint (\x03) to terminal before running processing again
- To use, set `processing.shouldSendSigint` to `true`
	- Off by default to avoid cross-platform compatibility issues